### PR TITLE
Fix TLS collector retained memory growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed `TLSCollectorOptions::max_recycled_global_histograms_per_pool`; the recycled global histogram pool limit is now an internal constant.
+
 ## [0.3.1] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-16
+
 ### Changed
 - Removed `TLSCollectorOptions::max_recycled_global_histograms_per_pool`; the recycled global histogram pool limit is now an internal constant.
 


### PR DESCRIPTION
## Summary
- reuse global histogram pool storage during TLS merge/drain paths
- keep recycled global histogram pool limit internal instead of exposing it in options
- add retained-state convergence coverage for repeated TLS metric drains
- fix CI cargo-fuzz install and benchmark threshold handling
- document the TLS option removal in the changelog

## Tests
- cargo test --features tls-collector --lib tls_repeated_same_metric_drains_converge_retained_state
- cargo test --features tls-collector --lib
- cargo test --all-features --lib
- cargo clippy --all-targets --all-features -- -D warnings